### PR TITLE
Fix encoding error during model_cards.json load on Windows.

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,7 +75,7 @@ summarization_configs = [
     if isfile(join("configs/summarization_configs", f))
 ]
 
-model_info = json.load(open("model_cards.json"))
+model_info = json.load(open("model_cards.json", "r", encoding="utf8"))
 table_data = []
 
 for name, attributes in model_info.items():


### PR DESCRIPTION
It looks like specifying UTF-8 encoding explicit is needed on Windows for select proper decoder.